### PR TITLE
Fix typo in "Streaming Support" link

### DIFF
--- a/Contribute.html
+++ b/Contribute.html
@@ -68,7 +68,7 @@ $('#responses div').show();
 <li target="https://github.com/timvideos/getting-started/labels/Project%20-%20Flumotion" data-choice-id="flumotin">Flumotion
 <div class="extra" data-l10n-id="flumotion-extra"></div>
 </li>
-<li target="https://github.com/timvidoes/getting-started" data-choice-id="streaming">Streaming Support
+<li target="https://github.com/timvideos/getting-started" data-choice-id="streaming">Streaming Support
 <div class="extra" data-l10n-id="streaming-extra"></div>
 </li>
 </ul>


### PR DESCRIPTION
It doesn't link to a specific label, because I'm not sure what the correct one is, but at least it is not a dead link anymore.